### PR TITLE
Port change on 'help getbalance'

### DIFF
--- a/src/rpc/server.cpp
+++ b/src/rpc/server.cpp
@@ -516,7 +516,7 @@ std::string HelpExampleCli(const std::string& methodname, const std::string& arg
 std::string HelpExampleRpc(const std::string& methodname, const std::string& args)
 {
     return "> curl --user myusername --data-binary '{\"jsonrpc\": \"1.0\", \"id\":\"curltest\", "
-        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:8332/\n";
+        "\"method\": \"" + methodname + "\", \"params\": [" + args + "] }' -H 'content-type: text/plain;' http://127.0.0.1:9232/\n";
 }
 
 void RPCSetTimerInterfaceIfUnset(RPCTimerInterface *iface)


### PR DESCRIPTION
Port in the help description currently states the wrong RPC port. Changed to default Gulden RPC port.