### PR TITLE
Makes dbinc/atomic.h writable

### DIFF
--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -17,7 +17,7 @@ endef
 
 define $(package)_preprocess_cmds
   chmod a+w dbinc/atomic.h dbinc/atomic.h && \
-  sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' dbinc/atomic.h dbinc/atomic.h && \
+  sed -i.old2 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' dbinc/atomic.h dbinc/atomic.h && \
   sed -i.old 's/atomic_init/atomic_init_db/' dbinc/atomic.h mp/mp_region.c mp/mp_mvcc.c mp/mp_fget.c mutex/mut_method.c mutex/mut_tas.c && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist
 endef

--- a/depends/packages/bdb.mk
+++ b/depends/packages/bdb.mk
@@ -16,7 +16,8 @@ $(package)_cflags_ios=-Wno-implicit-function-declaration
 endef
 
 define $(package)_preprocess_cmds
-  sed -i.old2 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' dbinc/atomic.h dbinc/atomic.h && \
+  chmod a+w dbinc/atomic.h dbinc/atomic.h && \
+  sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/g' dbinc/atomic.h dbinc/atomic.h && \
   sed -i.old 's/atomic_init/atomic_init_db/' dbinc/atomic.h mp/mp_region.c mp/mp_mvcc.c mp/mp_fget.c mutex/mut_method.c mutex/mut_tas.c && \
   cp -f $(BASEDIR)/config.guess $(BASEDIR)/config.sub dist
 endef


### PR DESCRIPTION
This commit fixes a compilation error.
It occured on WSL2, but I don't think that's necessarily the cause of the problem