### PR TITLE
CORE: Fix Coin::DynamicMemoryUsage() for all output types

### DIFF
--- a/src/coins.h
+++ b/src/coins.h
@@ -119,7 +119,7 @@ public:
     }
 
     size_t DynamicMemoryUsage() const {
-        return memusage::DynamicUsage(out.output.scriptPubKey);
+        return RecursiveDynamicUsage(out);
     }
 };
 


### PR DESCRIPTION
For output types other than scriptPubKey the return value is currently
undefined and often quite large. This causes FlushStateToDisk() to flush
basically every single state change, due to the cache being 'too large'.