### PR TITLE
Update dependency download URLs

### DIFF
--- a/depends/packages/boost.mk
+++ b/depends/packages/boost.mk
@@ -1,6 +1,7 @@
 package=boost
 $(package)_version=1.77.0
-$(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
+# $(package)_download_path=https://boostorg.jfrog.io/artifactory/main/release/$($(package)_version)/source/
+$(package)_download_path=https://archives.boost.io/release/1.77.0/source/
 $(package)_file_name=boost_$(subst .,_,$($(package)_version)).tar.bz2
 $(package)_sha256_hash=fc9f85fc030e233142908241af7a846e60630aa7388de9a5fafb1f3a26840854
 

--- a/depends/packages/openssl.mk
+++ b/depends/packages/openssl.mk
@@ -1,6 +1,7 @@
 package=openssl
 $(package)_version=1.0.1k
-$(package)_download_path=https://www.openssl.org/source/old/1.0.1
+# $(package)_download_path=https://www.openssl.org/source/old/1.0.1
+$(package)_download_path=https://github.com/openssl/openssl/releases/download/OpenSSL_1_0_1k
 $(package)_file_name=$(package)-$($(package)_version).tar.gz
 $(package)_sha256_hash=8f9faeaebad088e772f4ef5e38252d472be4d878c6b3a2718c10a4fcebe7a41c
 $(package)_patches=0001-Update-configure-for-m1-builds.patch

--- a/depends/packages/qrencode.mk
+++ b/depends/packages/qrencode.mk
@@ -1,6 +1,7 @@
 package=qrencode
 $(package)_version=3.4.4
-$(package)_download_path=https://fukuchi.org/works/qrencode/
+# $(package)_download_path=https://fukuchi.org/works/qrencode/
+$(package)_download_path=https://eternallybored.org/misc/glabels/src/
 $(package)_file_name=$(package)-$($(package)_version).tar.bz2
 $(package)_sha256_hash=efe5188b1ddbcbf98763b819b146be6a90481aac30cfc8d858ab78a19cde1fa5
 


### PR DESCRIPTION
This PR updates several outdated dependency download URLs used by the depends build system.

The original download locations are no longer available or no longer provide the expected source archives, causing clean builds to fail.

Updated download locations:

- Boost 1.77.0
from the deprecated JFrog Artifactory mirror
to the official Boost archive

- OpenSSL 1.0.1k
from the removed OpenSSL archive
to the official GitHub release archive

- qrencode 3.4.4
from the original project website (no longer hosting the release)
to a mirror that still provides the original source archive

The downloaded files are identical to the expected versions and match the existing SHA256 checksums.

This restores the ability to perform a clean build using the depends system without requiring manual intervention.