### PR TITLE
Allow inbound peers during Initial Block Download

### DIFF
--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -2219,7 +2219,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         LOCK(cs_main);
         static bool fRegTest = Params().IsRegtest();
         static bool fRegTestLegacy = Params().IsRegtestLegacy();
-        if (IsInitialBlockDownload() && !pfrom->fWhitelisted && !fRegTest && !fRegTestLegacy)
+        if (IsInitialBlockDownload() && !pfrom->fInbound && !pfrom->fWhitelisted && !fRegTest && !fRegTestLegacy)
         {
             LogPrint(BCLog::NET, "Ignoring getheaders from peer=%d because node is in initial block download\n", pfrom->GetId());
             return true;
@@ -2276,7 +2276,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         vRecv >> height >> num;
 
         LOCK(cs_main);
-        if (IsInitialBlockDownload() && !pfrom->fWhitelisted && !IsArgSet("-regtest"))
+        if (IsInitialBlockDownload() && !pfrom->fInbound && !pfrom->fWhitelisted && !IsArgSet("-regtest"))
         {
             LogPrint(BCLog::NET, "Ignoring getrheaders from peer=%d because node is in initial block download\n", pfrom->GetId());
             return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1804,6 +1804,32 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
                 pfrom->fDisconnect = true;
                 return false;
             }
+            
+            // During Initial Block Download (IBD), avoid using outbound peers that are
+            // still below the last checkpoint, as they cannot help us synchronize.
+            //
+            // However, do not disconnect inbound peers. On a mature or mostly inactive
+            // network, a fully synchronized node may still report IsInitialBlockDownload()
+            // because the chain tip is older than the IBD threshold. In that situation,
+            // new nodes typically connect with nStartingHeight == 0 and rely on inbound
+            // connections to bootstrap. Disconnecting them would prevent synchronization.
+            if (IsInitialBlockDownload() && !pfrom->fInbound)
+            {
+                if (pfrom->nStartingHeight < Checkpoints::LastCheckPointHeight() &&
+                    Checkpoints::LastCheckPointHeight() != 0)
+                {
+                    LOCK(cs_main);
+
+                    LogPrint(BCLog::NET,
+                            "Disconnecting outbound peer=%d: startheight=%d below checkpoint=%d during IBD\n",
+                            pfrom->GetId(),
+                            pfrom->nStartingHeight,
+                            Checkpoints::LastCheckPointHeight());
+
+                    pfrom->fDisconnect = true;
+                    return false;
+                }
+            }
         }
 
         return true;

--- a/src/net_processing.cpp
+++ b/src/net_processing.cpp
@@ -1798,13 +1798,6 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
         // They will only slow the sync down
         if (IsInitialBlockDownload())
         {
-            if (pfrom->nStartingHeight < Checkpoints::LastCheckPointHeight() && Checkpoints::LastCheckPointHeight() != 0)
-            {
-                LOCK(cs_main);
-                pfrom->fDisconnect = true;
-                return false;
-            }
-            
             // During Initial Block Download (IBD), avoid using outbound peers that are
             // still below the last checkpoint, as they cannot help us synchronize.
             //
@@ -1813,7 +1806,7 @@ bool static ProcessMessage(CNode* pfrom, const std::string& strCommand, CDataStr
             // because the chain tip is older than the IBD threshold. In that situation,
             // new nodes typically connect with nStartingHeight == 0 and rely on inbound
             // connections to bootstrap. Disconnecting them would prevent synchronization.
-            if (IsInitialBlockDownload() && !pfrom->fInbound)
+            if (!pfrom->fInbound)
             {
                 if (pfrom->nStartingHeight < Checkpoints::LastCheckPointHeight() &&
                     Checkpoints::LastCheckPointHeight() != 0)


### PR DESCRIPTION
### Summary

Do not disconnect inbound peers during Initial Block Download (IBD) solely because
their reported start height is below the last checkpoint.

### Background

While testing public Docker-based Munt nodes, fully synchronized nodes were still
reporting:

- blocks = 1856015
- headers = 1856015
- verificationprogress = 1
- initialblockdownload = true

Because the current chain tip is older than the IBD threshold, IsInitialBlockDownload()
remains true even though the node is fully synchronized.

The existing logic disconnects every peer whose start height is below the last
checkpoint:

```cpp
if (IsInitialBlockDownload())
{
    if (pfrom->nStartingHeight < Checkpoints::LastCheckPointHeight())
    {
        pfrom->fDisconnect = true;
        return false;
    }
}