### PR TITLE
Add active DNS bootstrap nodes

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -138,6 +138,10 @@ public:
         //vSeeds.push_back(CDNSSeedData("seed 3",  "seed.gulden.network"));
         //vSeeds.push_back(CDNSSeedData("seed 4",  "seed.gulden.blue"));
 
+        // Add working seed nodes for the Munt network
+        vSeeds.push_back(CDNSSeedData("seed 3",  "node1.abyte.eu", false));
+        vSeeds.push_back(CDNSSeedData("seed 4",  "node2.abyte.eu", false));
+
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,38);// 'G'
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,98);// 'g'
         base58Prefixes[POW2_WITNESS_ADDRESS] = std::vector<unsigned char>(1,73);// 'W'


### PR DESCRIPTION
Adds two currently maintained Munt nodes to the DNS seed list:

```
node1.abyte.eu
node2.abyte.eu
```

Both nodes run the current upstream Munt Core and have been verified to serve a fresh wallet syncing from genesis.

Existing legacy Gulden DNS seeds are retained for backwards compatibility.